### PR TITLE
Autenticação: permitir login por usuário ou e‑mail e migrar senhas legadas para hash

### DIFF
--- a/Web/projeto/foodverse/views.py
+++ b/Web/projeto/foodverse/views.py
@@ -208,12 +208,27 @@ def login_view(request):
         return redirect('home')
 
     if request.method == 'POST':
-        username = request.POST.get('username')
-        password = request.POST.get('password')
+        login = request.POST.get('username', '').strip()
+        password = request.POST.get('password', '')
         remember_me = request.POST.get('remember_me')
 
-        cliente = TbClientes.objects.filter(username=username).first()
-        if cliente and check_password(password, cliente.senha):
+        cliente = TbClientes.objects.filter(
+            Q(username__iexact=login) | Q(email__iexact=login)
+        ).first()
+
+        senha_valida = bool(
+            cliente and cliente.senha and (
+                check_password(password, cliente.senha) or password == cliente.senha
+            )
+        )
+
+        if cliente and senha_valida:
+            # Migração transparente: se a senha antiga estiver em texto puro,
+            # converte para hash no primeiro login bem-sucedido.
+            if password == cliente.senha:
+                cliente.senha = make_password(password)
+                cliente.save(update_fields=['senha'])
+
             request.session['cliente_id'] = cliente.id_cliente
             request.session.set_expiry(1209600 if remember_me else 0)
             messages.success(request, 'Login realizado com sucesso!')


### PR DESCRIPTION
### Motivation
- O formulário de login aceita "usuário ou e-mail" mas o backend só consultava `username`, impedindo logins por e‑mail.
- Dados de seed/históricos gravavam `tb_clientes.senha` em texto plano, enquanto o sistema validava apenas hashes, causando falha de autenticação para usuários existentes.
- É desejável uma migração suave das senhas legadas sem exigir scripts de migração explícitos imediatamente.

### Description
- Atualiza `login_view` em `Web/projeto/foodverse/views.py` para buscar o cliente por `username` **ou** `email` usando `Q(username__iexact=login) | Q(email__iexact=login)`.
- Introduz validação compatível com senhas já hasheadas (`check_password`) ou senhas legadas em texto puro, com a checagem `check_password(password, cliente.senha) or password == cliente.senha`.
- Implementa migração transparente que, no primeiro login bem‑sucedido com senha legada em texto claro, regrava `cliente.senha` com `make_password(password)` e salva o registro.

### Testing
- Execução de verificação do projeto via `python3 Web/projeto/manage.py check` foi tentada e **falhou** devido à ausência do pacote `django` no ambiente de execução (limitação do ambiente, não do código).
- Não há testes automatizados definidos para autenticação em `Web/projeto/foodverse/tests.py` (arquivo vazio), logo nenhum teste unitário específico foi executado.
- Validação local do patch (commit) foi realizada no repositório; alterações aplicadas em `Web/projeto/foodverse/views.py` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b88bfb73208330867a0351a9b5c00c)